### PR TITLE
ML-341 Bundle file needed to specify version

### DIFF
--- a/Bundle.ecl
+++ b/Bundle.ecl
@@ -1,0 +1,10 @@
+EXPORT Bundle := MODULE(Std.BundleBase)
+  EXPORT Name := ‘ML_Core’;
+  EXPORT Description := ‘Common definitions for Machine Learning’;
+  EXPORT Authors := [‘HPCCSystems’];
+  EXPORT License := 'http://www.apache.org/licenses/LICENSE-2.0';
+  EXPORT Copyright := 'Copyright (C) 2017 HPCC Systems®';
+  EXPORT DependsOn := [];
+  EXPORT Version := ‘3.0.0’;
+  EXPORT PlatformVersion := ‘6.2.0’;
+END;


### PR DESCRIPTION
Add the Bundle attribute so the version of the ML_Core bundle can be specified.

Signed-off-by: johnholt <john.d.holt@lexisnexis.com>