### PR TITLE
ML-336 Beta function correction for large input values

### DIFF
--- a/Math/Beta.ecl
+++ b/Math/Beta.ecl
@@ -1,7 +1,10 @@
-IMPORT $ AS Utils;
-gamma := Utils.gamma;
+IMPORT $ AS Math;;
+gamma := Math.gamma;
+log_gamma := Math.log_gamma;
+MAXGAM := 171;
+ASYMP := 1000000; //1e6
 /**
- * Return the beta value of two real numbers, x and y
+ * Return the beta value of two positive real numbers, x and y
  *@param x  the value of the first number
  *@param y  the value of the second number
  *@return   the beta value
@@ -19,7 +22,20 @@ EXPORT Beta(REAL8 x, REAL8 y) := FUNCTION
    isYfail := absy<1.0e-9 OR (y<0 AND (isYRightInt OR isYLeftInt));
    bp := gamma(x)*gamma(y)/gamma(x+y);
    bn :=(x+y)*gamma(x+1)*gamma(y+1)/(x*y*gamma(x+y+1));
-   b := MAP(
+   use_b_log := x+y>MAXGAM OR x>MAXGAM OR y>MAXGAM;
+   b_log := log_gamma(x) + log_gamma(y) - log_gamma(x+y);
+   use_y_asymp := x > ASYMP AND x > ASYMP * y;
+   y_asymp := log_gamma(y) - y*LN(x) + y*(1-y)/(2*x)
+            + y*(1-y)*(1-2*y)/(12*x*x)
+            - y*y*(1-y)*(1-y)/(12*x*x*x);
+   use_x_asymp := y > ASYMP AND y > ASYMP * x;
+   x_asymp := log_gamma(x) - x*LN(y) + x*(1-x)/(2*y)
+            + x*(1-x)*(1-2*x)/(12*y*y)
+            - x*x*(1-x)*(1-x)/(12*y*y*y);
+   // choose the right definition to use
+   b := MAP(x>0 AND y>0 AND use_y_asymp => EXP(y_asymp),
+            x>0 AND y>0 AND use_x_asymp => EXP(x_asymp),
+            x>0 AND y>0 AND use_b_log => EXP(b_log),
             x>0 AND y>0 => bp,
             isXfail OR isYfail => 9999, //failed, negative or zero ints
             bn //when both x and y negative real numbers

--- a/Math/log_gamma.ecl
+++ b/Math/log_gamma.ecl
@@ -1,0 +1,14 @@
+/**
+ * Return the value of the log gamma function of the absolute value
+ * of X.
+ * A wrapper for the standard C lgamma function.  Avoids the race
+ * condition found on some platforms by taking the absolute value of the
+ * of the input argument.
+ *@param x the input x
+ *@return the value of the log of the GAMMA evaluated at ABS(x)
+ */
+EXPORT REAL8 log_gamma(REAL8 x) := BEGINC++
+  #option pure
+  #include <math.h>
+  return lgamma(fabs(x));
+ENDC++;

--- a/Tests/Validate_Betas.ecl
+++ b/Tests/Validate_Betas.ecl
@@ -1,0 +1,71 @@
+// Compare Beta against the scipy implementation of Beta for validation
+//We only expose the Beta at this point, but test is intended to be
+//expanded to add the incomplete (lower) Beta.
+IMPORT ML_Core;
+IMPORT ML_Core.Math;
+IMPORT Python;
+REAL8 scipy_beta(REAL8 x, REAL8 y) := EMBED(Python)
+  import scipy;
+  import scipy.special;
+  return scipy.special.beta(x,y);
+ENDEMBED;
+//Test design cases
+// 1) Two positive integers, both under 171 and sum under 171
+// 2) Two positive integers, at least one or sum over 171
+// 3) Two positive reals, both under 171 and sum under 171
+// 4) two positive reals, at least one or sum over 171
+// 5) one negative integer
+// 6) two negative integers
+// 7) one negative real
+// 8) two negative real values
+// 9) two positives, one > 1e6
+Layout_Test_Values := RECORD
+  REAL8 x;
+  REAL8 y;
+  UNSIGNED1 test_case;
+END;
+test_set := DATASET([{              1.0,              1.0, 1},
+                     {            150.0,             15.0, 1},
+                     {             15.0,            150.0, 1},
+                     {            120.0,             60.0, 2},
+                     {            900.0,              2.0, 2},
+                     {              2.0,            200.0, 2},
+                     {              3.25,             7.6, 3},
+                     {              7.6,             3.25, 3},
+                     {              0.5,            200.5, 4},
+                     {            200.3,              0.5, 4},
+                     {             -2.0,              0.9, 5},
+                     {           -200.0,            100.0, 5},
+                     {            -10.0,            -20.0, 6},
+                     {            -19.2,             51.0, 7},
+                     {             13.3,            -19.2, 7},
+                     {           -190.2,            -87.9, 8},
+                     {        1000000.0,        0.00001,   9},
+                     {      100000000.0,              5.0, 9},
+                     {      100000017.0,             13.0, 9},
+                     {   100000000000.0,      100000000.5, 9},
+                     {      100000567.0,              7.0, 9},
+                     {             10.0,     1000005670.0, 9}],
+                    Layout_Test_Values);
+REAL8 epsilon := 0.000001;
+Layout_Test_Result := RECORD
+  REAL8 ecl_value;
+  REAL8 sci_value;
+  BOOLEAN pass;
+  UNSIGNED1 test_case;
+  REAL8 x;
+  REAL8 y;
+END;
+Layout_Test_Result test_func(Layout_Test_Values tv) := TRANSFORM
+  ecl_value := Math.Beta(tv.x, tv.y);
+  sci_value := scipy_beta(tv.x, tv.y);
+  abs_diff :=  ABS(SELF.ecl_value - SELF.sci_value);
+  abs_ratio := abs_diff/MAX(ABS(ecl_value), ABS(sci_value));
+  SELF.ecl_value := ecl_value;
+  SELF.sci_value := sci_value;
+  SELF.pass := SELF.ecl_value=SELF.sci_value OR abs_ratio <= epsilon;
+  SELF := tv;
+END;
+rslt := PROJECT(test_set, test_func(LEFT));
+
+EXPORT Validate_Betas := OUTPUT(rslt);


### PR DESCRIPTION
Eliminates the NaN cases for large positive numbers.

Small negative real values can be OK.

Signed-off-by: johnholt <john.d.holt@lexisnexis.com>