### PR TITLE
ML-354 Add imports to code generated by macros

### DIFF
--- a/AppendID.ecl
+++ b/AppendID.ecl
@@ -13,6 +13,7 @@
 //    ML.AppendID(dOrig, recID, dOrigWithId);
 //---------------------------------------------------------------------------
 EXPORT AppendID(dIn,idfield,dOut) := MACRO
+  IMPORT Std.System.ThorLib;
   #uniquename(dInPrep)
   %dInPrep%:=TABLE(dIn,{ML_Core.Types.t_RecordID idfield:=0;dIn;});
   #uniquename(tra)

--- a/ToField.ecl
+++ b/ToField.ecl
@@ -98,7 +98,7 @@ EXPORT ToField(dIn,dOut,idfield='', wifield='', wivalue='',datafields=''):=MACRO
   #APPEND(tonumber,'0);')
   #EXPAND(%'tonumber'%)
   // Produce the output, with one row for every id/axis combination.
-  dOut:=NORMALIZE(dIn,%iNumberOfFields%,TRANSFORM(Types.NumericField,
+  dOut:=NORMALIZE(dIn,%iNumberOfFields%,TRANSFORM(ML_Core.Types.NumericField,
                   SELF.wi:=#EXPAND(%'use_for_wi'%),
                   SELF.id:=LEFT.#EXPAND(%'foundidfield'%),
                   SELF.number:=COUNTER,

--- a/Utils/SequenceInField.ecl
+++ b/Utils/SequenceInField.ecl
@@ -14,6 +14,7 @@
  *@return a file of the same type with sequence numbers applied
  */
 EXPORT SequenceInField(infile,infield,seq,wi_name='wi') := FUNCTIONMACRO
+  IMPORT Std.System.ThorLib;
   LOCAL extend_rec := RECORD(RECORDOF(infile))
     UNSIGNED2 __node;
   END;


### PR DESCRIPTION
The recommended fix of IMPORT ML_Core.Types AS %types% was not needed in this case.  The reference was changed from Types... to ML_Core.Types because the user had to import ML_Core to get the macro.  The other changes were to add imports to the Std.System.ThorLib module.

Signed-off-by: johnholt <john.d.holt@lexisnexis.com>