### PR TITLE
ML-359 Missing import

### DIFF
--- a/Bundle.ecl
+++ b/Bundle.ecl
@@ -6,6 +6,6 @@ EXPORT Bundle := MODULE(Std.BundleBase)
   EXPORT License := 'See LICENSE.TXT';
   EXPORT Copyright := 'Copyright (C) 2017 HPCC Systems®';
   EXPORT DependsOn := [];
-  EXPORT Version := '3.1.0';
+  EXPORT Version := '3.1.1';
   EXPORT PlatformVersion := '6.2.0';
 END;

--- a/ToField.ecl
+++ b/ToField.ecl
@@ -38,6 +38,7 @@
 //    dMatrix_Map; // returns the mapping table of field name to number
 //---------------------------------------------------------------------------
 EXPORT ToField(dIn,dOut,idfield='', wifield='', wivalue='',datafields=''):=MACRO
+  IMPORT ML_Core;
   LOADXML('<xml/>');
   // Variable to contain the name if the field that maps to "wi", or the value
   #DECLARE(use_for_wi);
@@ -79,7 +80,7 @@ EXPORT ToField(dIn,dOut,idfield='', wifield='', wivalue='',datafields=''):=MACRO
           #APPEND(mapping,',{\''+%'{@label}'%+'\',\'WI\'}')
         #ELSE
           #IF(REGEXREPLACE('[^a-z]',%'{@type}'%,'') IN ['unsigned','integer','real','decimal','udecimal'] #IF(#TEXT(datafields)!='') AND REGEXFIND('\\s*,\\s*'+%'{@label}'%+',',','+datafields+',',NOCASE) #END)
-            #APPEND(normlist,',(Types.t_FieldReal)LEFT.'+%'{@label}'%)
+            #APPEND(normlist,',(ML_Core.Types.t_FieldReal)LEFT.'+%'{@label}'%)
             #SET(iNumberOfFields,%iNumberOfFields%+1)
             #APPEND(mapping,',{\''+%'{@label}'%+'\',\''+%'iNumberOfFields'%+'\'}')
             #APPEND(toname,'i='+%'iNumberOfFields'%+'=>\''+%'{@label}'%+'\',')


### PR DESCRIPTION
Atribute did not have a specific imort and instead relied upon the using attribute to have set up an import aliased to a specific name.  Added an import for ML_Core, and then used the explicit module name for the types.

Signed-off-by: johnholt <john.d.holt@lexisnexisrisk.com>