### PR TITLE
ML-349  Add IRegression2 and Model2 definitions to ML_Core

### DIFF
--- a/Analysis.ecl
+++ b/Analysis.ecl
@@ -1,0 +1,228 @@
+/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.  All rights reserved.
+############################################################################## */
+IMPORT $ AS ML_Core;
+IMPORT ML_Core.Types;
+
+DiscreteField := Types.DiscreteField;
+NumericField := Types.NumericField;
+t_Work_Item := Types.t_Work_Item;
+t_RecordId := Types.t_RecordId;
+t_FieldNumber := Types.t_FieldNumber;
+t_FieldReal := Types.t_FieldReal;
+t_Discrete := Types.t_Discrete;
+Class_Stats := Types.Class_Stats;
+Confusion_Detail := Types.Confusion_Detail;
+Classification_Accuracy := Types.Classification_Accuracy; // Return structure for
+                                                          // Classification.Accuracy
+Class_Accuracy := Types.Class_Accuracy; // Return structure for Classification.AccuracyByClass
+Regression_Accuracy := Types.Regression_Accuracy; // Return structure for Regression.Accuracy
+
+/**
+  * This module provides functions for analyzing and assessing the effectiveness of a Machine
+  * Learning model.
+  *
+  * Each of these functions support multi-work-item (i.e. Myriad interface) data, as well as
+  * multi-variate data (supported by some ML bundles).  The number field, which is usually
+  * = 1 for uni-variate data is used to distinguish multiple regressors in the case of multi-
+  * variate models.
+  *
+  */
+EXPORT Analysis := MODULE
+  /**
+    * This sub-module provides functions for analyzing and assessing the effectiveness of
+    * an ML Classification model.  It can be used with any ML Bundle that supports classification.
+    */
+  EXPORT Classification := MODULE
+    /**
+      * Given a set of expected dependent values, assess the number and percentage of records that
+      * were of each class.
+      *
+      * @param actual The set of training-data or test-data dependent values in DATASET(DiscreteField)
+      *               format.
+      * @return DATASET(Class_Stats), one record per work-item, per classifier (i.e. number field) per
+      *         class.
+      * @see ML_Core.Types.Class_Stats
+      */
+    EXPORT DATASET(Class_Stats) ClassStats(DATASET(DiscreteField) actual) := FUNCTION
+      // Returns for each class: label, count, pct
+      recStats := TABLE(actual, {wi, number, cnt := COUNT(GROUP)}, wi, number);
+      cStats := TABLE(actual, {wi, number, value, cnt := COUNT(GROUP)}, wi, number, value);
+      outStats := JOIN(cStats, recStats, LEFT.wi = RIGHT.wi AND LEFT.number = RIGHT.number,
+                      TRANSFORM(Class_Stats,
+                                  SELF.classifier := LEFT.number,
+                                  SELF.class := LEFT.value,
+                                  SELF.classCount := LEFT.cnt,
+                                  SELF.classPct := LEFT.cnt / RIGHT.cnt,
+                                  SELF := LEFT), LOOKUP);
+      RETURN outStats;
+    END; // ClassStats
+    // Function to compare predicted and actual values and include them in a record set containing both,
+    // as well as a 'correct' indicator, which is TRUE whenever the two match.
+    SHARED CompareClasses(DATASET(DiscreteField) predicted, DATASET(DiscreteField) actual) := FUNCTION
+      // Distribute predicted and actual by HASH32(wi, id)
+      predD := DISTRIBUTE(predicted, HASH32(wi, id));
+      actD := DISTRIBUTE(actual, HASH32(wi, id));
+      cmp := JOIN(predD, actD, LEFT.wi = RIGHT.wi AND LEFT.number = RIGHT.number AND LEFT.id = RIGHT.id,
+                  TRANSFORM({t_Work_Item wi, t_FieldNumber number, t_Discrete pred, t_discrete actual, BOOLEAN correct},
+                              SELF.pred := LEFT.value,
+                              SELF.actual := RIGHT.value,
+                              SELF.correct := LEFT.value = RIGHT.value,
+                              SELF := LEFT), LOCAL);
+      // cmp is distributed by HASH32(wi, id)
+      RETURN cmp;
+    END; // CompareClasses
+    /**
+      * Returns the Confusion Matrix, counting the number of cases for each combination of predicted Class and
+      * actual Class.
+      *
+      * @param predicted The predicted values for each id in DATASET(DiscreteField) format
+      * @param actual The actual (i.e. expected) values for each id in DATASET(DiscreteField) format
+      * @return DATASET(Confusion_Detail).  One record for each combination of work-item, number (i.e. classifier),
+      *         predicted class, and actual class.
+      * @see ML_Core.Types.Confusion_Detail
+      *
+      */
+    EXPORT DATASET(Confusion_Detail) ConfusionMatrix(DATASET(DiscreteField) predicted, DATASET(DiscreteField) actual) := FUNCTION
+      cmp := CompareClasses(predicted, actual);
+      // Count the number of samples that were actually of each class
+      actualClassTots := TABLE(cmp, {wi, number, actual, tot := COUNT(GROUP)}, wi, number, actual);
+      // Count the number of samples that were predicted for each class
+      predClassTots := TABLE(cmp, {wi, number, pred, tot := COUNT(GROUP)}, wi, number, pred);
+      // Count the number of samples for each combination of actual and predicted
+      cm0 := TABLE(cmp, {wi, t_FieldNumber classifier := number,
+                          t_Discrete actual_class := actual, t_Discrete predict_class := pred,
+                          UNSIGNED4 occurs := COUNT(GROUP), BOOLEAN correct := pred = actual}, wi, number, actual, pred);
+      // Now calculate the proportions (of both actual and predicted values for each combination)
+      cm1 := JOIN(cm0, actualClassTots, LEFT.wi = RIGHT.wi AND LEFT.classifier = RIGHT.number
+                      AND LEFT.actual_class = RIGHT.actual,
+                    TRANSFORM({RECORDOF(LEFT), t_FieldReal pctActual},
+                                SELF.pctActual := LEFT.occurs / RIGHT.tot,
+                                SELF := LEFT), LOOKUP);
+      cm2 := JOIN(cm1, predClassTots, LEFT.wi = RIGHT.wi AND LEFT.classifier = RIGHT.number
+                      AND LEFT.predict_class = RIGHT.pred,
+                    TRANSFORM({RECORDOF(LEFT), t_FieldReal pctPred},
+                                SELF.pctPred := LEFT.occurs / RIGHT.tot,
+                                SELF := LEFT), LOOKUP);
+      cm := PROJECT(cm2, Confusion_Detail);
+      RETURN cm;
+    END; // ConfusionMatrix
+    /**
+      * Assess the overall accuracy of the classification predictions
+      *
+      * ML_Core.Types.Classification_Accuracy provides a detailed description of the return values. 
+      *
+      * @param predicted The predicted values for each id in DATASET(DiscreteField) format
+      * @param actual The actual (i.e. expected) values for each id in DATASET(DiscreteField) format
+      * @return DATASET(Classification_Accuracy).  One record for each combination of work-item, and
+      *         number (i.e. classifier).
+      * @see ML_Core.Types.Classification_Accuracy
+      *
+      */
+    EXPORT DATASET(Classification_Accuracy) Accuracy(DATASET(DiscreteField) predicted, DATASET(DiscreteField) actual) := FUNCTION
+      // Returns Raw, PoD, PoDE
+      cStats := ClassStats(actual);
+      numClasses := TABLE(cStats, {wi, classifier, num_classes := COUNT(GROUP)}, wi, classifier);
+      mostCommon0 := SORT(cStats, wi, classifier, -classCount);
+      mostCommon := DEDUP(mostCommon0, wi, classifier);
+      globStats := JOIN(numClasses, mostCommon, LEFT.wi = RIGHT.wi AND LEFT.classifier = RIGHT.classifier,
+                        TRANSFORM({numClasses, UNSIGNED highestCnt},
+                                  SELF.highestCnt := RIGHT.classCount,
+                                  SELF := LEFT));
+      cmp := CompareClasses(predicted, actual);
+      cmpStats := TABLE(cmp, {wi, number, UNSIGNED corrCnt := COUNT(GROUP, correct), totCnt := COUNT(GROUP)}, wi, number);
+      outStats := JOIN(cmpStats, globStats, LEFT.wi = RIGHT.wi AND LEFT.number = RIGHT.classifier,
+                        TRANSFORM(Classification_Accuracy,
+                                   SELF.classifier := LEFT.number,
+                                   SELF.errCnt := LEFT.totCnt - LEFT.corrCnt,
+                                   SELF.recCnt := LEFT.totCnt,
+                                   SELF.Raw_accuracy := LEFT.corrCnt / LEFT.totCnt,
+                                   SELF.PoD := (LEFT.corrCnt -  LEFT.totCnt / RIGHT.num_classes) /
+                                                  (LEFT.totCnt - LEFT.totCnt / RIGHT.num_classes),
+                                   SELF.PoDE := (LEFT.corrCnt - RIGHT.highestCnt) /
+                                                  (LEFT.totCnt - RIGHT.highestCnt),
+                                   SELF := LEFT), LOOKUP);
+      RETURN outStats;
+    END; // Accuracy
+    /**
+      * Provides per class accuracy / relevance statistics (e.g. Precision / Recall,
+      * False-positive Rate).
+      * 
+      * ML_Core.Types.Class_Accuracy provides a detailed description of the return values. 
+      *
+      * @param predicted The predicted values for each id in DATASET(DiscreteField) format
+      * @param actual The actual (i.e. expected) values for each id in DATASET(DiscreteField) format
+      * @return DATASET(Class_Accuracy).  One record for each combination of work-item, number (i.e. classifier),
+      *         and class.
+      * @see ML_Core.Types.Class_Accuracy
+      *
+      */
+    EXPORT DATASET(Class_Accuracy) AccuracyByClass(DATASET(DiscreteField) predicted, DATASET(DiscreteField) actual) := FUNCTION
+      // Returns Precision, Recall, False Positive Rate(FPR)
+      allClasses0 := SORT(actual, wi, number, value);
+      allClasses := DEDUP(actual, wi, number, value);
+      cmp := CompareClasses(predicted, actual);
+      // For each class, replicate all of the items not of that class so that we can analyze that class
+      // with respect to its non-members (i.e. negatives).
+      allClassPts := JOIN(cmp, allClasses, LEFT.wi = RIGHT.wi AND LEFT.number = RIGHT.number,
+                          TRANSFORM({cmp, UNSIGNED class},
+                                      SELF.class := RIGHT.value,
+                                      SELF := LEFT), MANY, LOOKUP);
+      allClassSumm := TABLE(allClassPts, {wi, number, class,
+                             UNSIGNED precDenom := COUNT(GROUP, pred = class),
+                             UNSIGNED TP := COUNT(GROUP, pred = class AND actual = class),
+                             UNSIGNED FP := COUNT(GROUP, pred = class AND actual != class),
+                             UNSIGNED recallDenom := COUNT(GROUP, actual = class),
+                             UNSIGNED TN := COUNT(GROUP, actual != class AND pred != class),
+                             UNSIGNED FN := COUNT(GROUP, actual = class AND pred != class),
+                             }, wi, number, class);
+      cStats := PROJECT(allClassSumm, TRANSFORM(Class_Accuracy,
+                                            SELF.classifier := LEFT.number,
+                                            SELF.precision := LEFT.TP / (LEFT.TP + LEFT.FP),
+                                            SELF.recall := LEFT.TP / (LEFT.TP + LEFT.FN),
+                                            SELF.FPR := LEFT.FP / (LEFT.FP + LEFT.TN),
+                                            SELF := LEFT));
+      RETURN cStats;
+    END; // AccuracyByClass
+  END; // Classification
+  /**
+    * This sub-module provides functions for analyzing and assessing the effectiveness of
+    * an ML Regression model.  It can be used with any ML Bundle that supports regression.
+    *
+    */
+  EXPORT Regression := MODULE
+    /**
+      * Assess the overall accuracy of the regression predictions
+      *
+      * @param predicted The predicted values for each id in DATASET(DiscreteField) format
+      * @param actual The actual (i.e. expected) values for each id in DATASET(DiscreteField) format
+      * @return DATASET(Regression_Accuracy).  One record for each combination of work-item, and
+      *         number (i.e. regressor).
+      * @see ML_Core.Types.Regression_Accuracy
+      *
+      */
+    EXPORT DATASET(Regression_Accuracy) Accuracy(DATASET(NumericField) predicted, DATASET(NumericField) actual) := FUNCTION
+      // Returns R-squared, MSE, RMSE
+      meanAct := TABLE(actual, {wi, number, REAL mean := AVE(GROUP, value), cnt := COUNT(GROUP)}, wi, number);
+      cmp := JOIN(actual, predicted, LEFT.wi = RIGHT.wi AND LEFT.number = RIGHT.number AND LEFT.id = RIGHT.id,
+                    TRANSFORM({t_Work_Item wi, t_FieldNumber number, t_FieldReal actual, t_FieldReal pred},
+                      SELF.actual := LEFT.value,
+                      SELF.pred := RIGHT.value,
+                      SELF := LEFT));
+      calc0 := JOIN(cmp, meanAct, LEFT.wi = RIGHT.wi AND LEFT.number = RIGHT.number,
+                      TRANSFORM({cmp, REAL ts, REAL rs},
+                        SELF.ts := POWER(LEFT.actual - RIGHT.mean, 2), // Total squared
+                        SELF.rs := POWER(LEFT.actual - LEFT.pred, 2),  // Residual squared
+                        SELF := LEFT), LOOKUP);
+      // R2 := 1 - (Residual Sum of Squares / Total Sum of Squares)
+      calc1 := TABLE(calc0, {wi, number, R2 := 1 - SUM(GROUP, rs) / SUM(GROUP, ts), RSS := SUM(GROUP, rs)}, wi, number);
+      result := JOIN(calc1, meanAct, LEFT.wi = RIGHT.wi AND LEFT.number = RIGHT.number,
+                      TRANSFORM(Regression_Accuracy,
+                        SELF.MSE := LEFT.RSS / RIGHT.cnt,
+                        SELF.RMSE := POWER(SELF.MSE, .5),
+                        SELF.regressor := LEFT.number,
+                        SELF := LEFT), LOOKUP);
+      RETURN result;
+    END; // Accuracy
+  END; // Regression
+END; // Analysis

--- a/Bundle.ecl
+++ b/Bundle.ecl
@@ -6,6 +6,6 @@ EXPORT Bundle := MODULE(Std.BundleBase)
   EXPORT License := 'See LICENSE.TXT';
   EXPORT Copyright := 'Copyright (C) 2017 HPCC Systems®';
   EXPORT DependsOn := [];
-  EXPORT Version := '3.1.1';
+  EXPORT Version := '3.2.0';
   EXPORT PlatformVersion := '6.2.0';
 END;

--- a/CrossValidation.ecl
+++ b/CrossValidation.ecl
@@ -1,0 +1,181 @@
+/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.  All rights reserved.
+############################################################################## */
+IMPORT ML_Core;
+IMPORT ML_Core.Types as Types;
+/**
+  * This module is a container for any cross-validation methods
+  */
+EXPORT CrossValidation := MODULE
+  /**
+    * N-Fold Cross Validation
+    *
+    * N-Fold Cross Validation is a way to validate the effectiveness
+    * of a regression or classification without having to segregate
+    * test data from training data.
+    * The results of the N-Fold Cross Validation approximate the expected result
+    * of training on all of the data samples and testing those results on other
+    * data from the same distribution.
+    * This allows a model that is built on all available labeled data to be
+    * effectively assessed. Note that this process does not produce the target
+    * model, but only estimates the 'out-of-sample' error statistics that such
+    * a model would produce.
+    * The method is as follows:
+    * - Randomly split independent and dependent data into N (e.g. 10) 'folds'
+    * - Train N separate models, using N-1 of the folds as training data (e.g. 9)
+    * - Test each model using the 1 fold that was not in the training set
+    * - Aggregate the test results across the N tests
+    *
+    * Any of the HPCC Machine Learning methods may be used with N-Fold Cross Validation
+    * The ML module to be used is passed as a parameter.
+    * N-Fold Cross Validation can be used for regression or classification.  If the
+    * dependent data is in NumericField format, it is treated as a regression and
+    * regression analytics are returned.  If it is in DiscreteField format, then
+    * it is treated as a Classification, and Classification analytics are return.
+    * Using the wrong dependent data type for the given learner will result in un-
+    * handled errors.
+    * The returned MODULE exports the following attributes:
+    * For Classification:
+    * - ClassStats - Assesses Classes Contained in the Training Data (see Types.Class_Stats)
+    * - Accuracy Overall Accuracy of the classification (see Types.Classification_Accuracy)
+    * - AccuracyByClass Precision and Recall for each class (see Types.Class_Accuracy)
+    * - ConfusionMatrix Frequency of predicted / actual class pairings (see Types.Consusion_Detail)
+    * For Regression:
+    * - Accuracy (see Types.Regression_Accuracy)
+    *
+    * @param LearnerName The attribute that holds the instantiated ML module.
+    * @param IndepDS The independent data to be used for training and testing.
+    * @param DepDS The dependent data to be used for training and testing.
+    * @param NumFolds The number of folds to use.  Ten is typically considered adequate.
+    * @return Result MODULE with attributes for assessing the strength of the model
+    * 
+    */
+  EXPORT NFoldCV(LearnerName, IndepDS, DepDS, NumFolds) := FUNCTIONMACRO
+    SHARED learner:= LearnerName;
+    LOADXML('<xml/>');
+    #DECLARE(predictStr)
+    #DECLARE(analyzeStr)
+    #DECLARE(fields);
+    #EXPORTXML(fields, RECORDOF(DepDS));
+    #FOR(fields)
+      #FOR(Field)
+        #IF(%'{@label}'% = 'value')
+          #IF(%'{@type}'% = 'integer')
+            // DiscreteField -- Treat as Classification
+            #SET(predictStr, 'SHARED Predicted0 := learner.Classify(Mod, t_indep);\n')
+            #SET(analyzeStr, 'EXPORT ClassStats :=  ML_Core.Analysis.Classification.ClassStats(Actual);\n' +
+                          'EXPORT Accuracy := ML_Core.Analysis.Classification.Accuracy(Predicted, Actual);\n' +
+                          'EXPORT AccuracyByClass := ML_Core.Analysis.Classification.AccuracyByClass(Predicted, Actual);\n' +
+                          'EXPORT ConfusionMatrix := ML_Core.Analysis.Classification.ConfusionMatrix(Predicted, Actual);\n')
+          #ELSE
+            // NumericField -- Treat as Regression
+            #SET(predictStr, 'SHARED Predicted0 := learner.Predict(Mod, t_indep);\n')
+            #SET(analyzeStr, 'EXPORT Accuracy := ML_Core.Analysis.Regression.Accuracy(Predicted, Actual);\n')
+          #END
+        #END
+      #END
+    #END
+
+    idFoldRec := RECORD
+      Types.t_Work_Item wi;
+      Types.t_FieldNumber number; // For multi-variate
+      Types.t_FieldNumber fold;
+      Types.t_RecordID id;
+    END;
+    dsRecordRnd := RECORD(RECORDOF(DepDS))
+      Types.t_FieldNumber rnd := 0;
+    END; 
+    dsRecordRnd AddRandom(RECORDOF(DepDS) l) :=TRANSFORM
+      SELF.rnd := RANDOM();
+      SELF := l;
+    END;
+    FoldNDS(DATASET(RECORDOF(IndepDS)) indData, DATASET(RECORDOF(DepDS)) depData, DATASET(idFoldRec) ds_folds,
+              Types.t_Discrete num_fold) := MODULE
+      EXPORT trainIndep := JOIN(indData, ds_folds(fold <> num_fold), LEFT.wi = RIGHT.wi AND LEFT.id = RIGHT.id,
+                        TRANSFORM(RECORDOF(IndepDS), SELF.id:= LEFT.id,
+                          SELF.wi:= num_fold + (LEFT.wi - 1) * NumFolds, SELF := LEFT), LOCAL);
+      EXPORT trainDep   := JOIN(depData, ds_folds(fold <> num_fold), LEFT.wi = RIGHT.wi AND LEFT.id = RIGHT.id
+                          AND LEFT.number = RIGHT.number,
+                        TRANSFORM(RECORDOF(DepDS), SELF.id:= LEFT.id,
+                          SELF.wi:= num_fold + (LEFT.wi - 1) * NumFolds, SELF := LEFT), LOCAL);
+      EXPORT testIndep  := JOIN(indData, ds_folds(fold = num_fold), LEFT.wi = RIGHT.wi AND LEFT.id = RIGHT.id,
+                        TRANSFORM(RECORDOF(IndepDS), SELF.id:= LEFT.id,
+                          SELF.wi:= num_fold + (LEFT.wi - 1) * NumFolds, SELF := LEFT), LOCAL);
+      EXPORT testDep    := JOIN(depData, ds_folds(fold = num_fold), LEFT.wi = RIGHT.wi AND LEFT.id = RIGHT.id
+                          AND LEFT.number = RIGHT.number,
+                        TRANSFORM(RECORDOF(DepDS), SELF.id:= LEFT.id,
+                          SELF.wi:= num_fold + (LEFT.wi - 1) * NumFolds, SELF := LEFT), LOCAL);
+    END;
+    dRnd := PROJECT(DepDS, AddRandom(LEFT), LOCAL);
+    dRndSorted := SORT(dRnd, wi, number, rnd);
+    ds_parts := DISTRIBUTE(PROJECT(dRndSorted, TRANSFORM(idFoldRec, SELF.fold := (COUNTER - 1) % NumFolds + 1, SELF:= LEFT)),
+                  HASH32(wi, id));
+    dIndep  := DISTRIBUTE(IndepDS, HASH32(wi, id));
+    dDep    := DISTRIBUTE(DepDS, HASH32(wi, id));
+    #DECLARE (FoldString)    #SET (FoldString, '');
+    #DECLARE (Ndx)
+    #SET (Ndx, 1);
+    #LOOP
+      #IF (%Ndx% > NumFolds)  
+         #BREAK         // break out of the loop
+      #ELSE             //otherwise
+        #APPEND(FoldString,'__fold'      + %'Ndx'% + '__ := FoldNDS(dIndep, dDep, ds_parts, ' + %'Ndx'% + '); \n');
+        #APPEND(FoldString,'__indepN'    + %'Ndx'% + '__ := __fold' + %'Ndx'% + '__.trainIndep; \n');
+        #APPEND(FoldString,'__depN'      + %'Ndx'% + '__ := __fold' + %'Ndx'% + '__.trainDep; \n');
+        #APPEND(FoldString,'__t_indepN'  + %'Ndx'% + '__ := __fold' + %'Ndx'% + '__.testIndep; \n');
+        #APPEND(FoldString,'__t_depN'    + %'Ndx'% + '__ := __fold' + %'Ndx'% + '__.testDep; \n');
+        #SET (Ndx, %Ndx% + 1)  //and increment the value of Ndx
+      #END
+    #END
+    #EXPAND(%'FoldString'%);
+
+    #SET (Ndx, 1);
+    #DECLARE (indep) #SET (indep, '__indep__ := ');
+    #DECLARE (dep) #SET (dep, '__dep__ := ');
+    #DECLARE (t_indep) #SET (t_indep, '__t_indep__ := ');
+    #DECLARE (t_dep) #SET (t_dep, '__t_dep__ := ');
+    #LOOP
+      #IF (%Ndx% < NumFolds)
+        #APPEND(indep,   '__indepN'   + %'Ndx'% + '__ + ');
+        #APPEND(dep,     '__depN'     + %'Ndx'% + '__ + ');
+        #APPEND(t_indep, '__t_indepN' + %'Ndx'% + '__ + ');
+        #APPEND(t_dep,   '__t_depN'   + %'Ndx'% + '__ + ');
+        #SET (Ndx, %Ndx% + 1)  //and increment the value of Ndx
+      #ELSE
+        #APPEND(indep,   '__indepN'   + %'Ndx'% + '__;\n');
+        #APPEND(dep,     '__depN'     + %'Ndx'% + '__;\n');
+        #APPEND(t_indep, '__t_indepN' + %'Ndx'% + '__;\n');
+        #APPEND(t_dep,   '__t_depN'   + %'Ndx'% + '__;\n');
+        #BREAK
+      #END
+    #END
+    #EXPAND(%'indep'%); // All Training Independents
+    #EXPAND(%'dep'%); // All Training Dependents
+    #EXPAND(%'t_indep'%); // All Testing Independents
+    #EXPAND(%'t_dep'%);  // All Testing Dependents
+
+    CVResults(DATASET(RECORDOF(IndepDS)) indep, DATASET(RECORDOF(DepDS)) dep,
+              DATASET(RECORDOF(IndepDS)) t_indep, DATASET(RECORDOF(DepDS)) t_dep) := MODULE
+      // At this point, each fold has been expanded out and converted to a unique work-item id.
+      // This gives us one wi per fold, per original wi.  The conversion is
+      // new_wi = foldNum + (orig_wi-1) * NumFolds)
+      SHARED Mod := learner.GetModel(indep, dep);
+      #EXPAND(%'predictStr'%)
+      // Now that we've built <number_of_work_items> * <NumFolds> models, and used those models
+      // to predict <orig_num_records> test points (that were not used in the training sets),
+      // We can (safely) combine all the test points back together for analysis.
+      // We do this by reversing the mapping of work items.
+      // The conversion is orig_wi = (new_wi -1) DIV NumFolds + 1.
+      // This is safe because each fold was only used once for test points, and because we've already done the
+      // ML prediction using the distinct models for each fold.
+      SHARED Predicted := PROJECT(Predicted0, TRANSFORM(RECORDOF(Predicted0),
+                            SELF.wi := (LEFT.wi - 1) DIV NumFolds + 1, SELF := LEFT));
+      SHARED Actual := PROJECT(t_dep, TRANSFORM(RECORDOF(t_dep),
+                            SELF.wi := (LEFT.wi - 1) DIV NumFolds + 1, SELF := LEFT));
+      #EXPAND(%'analyzeStr'%)
+      EXPORT Model := Mod;
+    END;
+    rslt := CVResults(__indep__, __dep__, __t_indep__, __t_dep__);
+    RETURN rslt;
+  ENDMACRO;
+END;

--- a/FromField.ecl
+++ b/FromField.ecl
@@ -1,25 +1,46 @@
-//---------------------------------------------------------------------------
-// Macro to reconstitute an original matrix from a NumericField-formatted
-// dataset.  In the simplest case, the assumption is that the field order
-// of the resulting table is in line with the field numbers in the input
-// dataset, with the ID field as the first field.  If a field mapping is
-// specified, this order can be re-arranged.
-//   dIn  : The name of the input dataset in NumericField format
-//   lOut : The name of the resulting layout the data should be in
-//   dOut : The name of the resulting dataset
-//   dMap : [OPTIONAL] If the user customized the fields used in the ToField
-//          process, they should include the mapping table that was created
-//          automatically by ToField here so the fields map back properly.
-//          This will be named NF_map, where NF is the name of the
-//          NumericField table that was created by ToField.
-//  Examples (used to reconstitute the ToField examples):
-//    ML.FromField(dMatrix,lOrig,dResults);
-//    ML.FromField(dMatrix,lOrig,dResults,dOrigData_Map);
-//
-// IMPORTANT NOTE: If fields in lOut were disregarded by the ToField macro
-// during the creation of the NumericField table, those fields WILL NOT be
-// reconstituted by this macro.  They will be left blank or zero.
-//---------------------------------------------------------------------------
+/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.  All rights reserved.
+############################################################################## */
+/**
+  * Macro to convert a NumericField formatted dataset to a Record formatted
+  * dataset.  Typically used to return converted NumericField data back to
+  * its original layout.
+  * 
+  * In the simplest case, the assumption is that the field order of the
+  * resulting table is in line with the field number in the input
+  * dataset, with the ID field as the first field.
+  * For example:
+  *   myRec := RECORD
+  *     UNSIGNED recordId;
+  *     REAL height;
+  *     REAL weight;
+  *   END;
+  *   Value of NumericField records with field number = 1 would go to height.
+  *   Value of NumericField records with field number = 2 would go to weight.
+  *   The id field of the NumericField record would be mapped to the recordId
+  *   field of the result.
+  *
+  * If the field orders have been changed (e.g. by customizing the ToField
+  * process, a field-mapping should be specified (See dMap below).
+  *
+  * Usage Examples:
+  *  ML.FromField(myNFData, myRecordLayout, myRecordData);
+  *  // Datamap to reorder the weight and height fields in the example above
+  *  dataMap := DATASET([{'weight', '1'},
+                         {'height', '2'}], Types.Field_Mapping);
+  *  ML.FromField(nyNFData, myRecordLayout, myRecordData, dataMap);
+  *
+  * @param dIn The name of the input dataset in NumericField format
+  * @param lOut The name of the layout record defining the records of the
+  *             result dataset
+  * @param dOut The name of the result dataset
+  * @param dMap [OPTIONAL] A Field_Mapping dataset as produced by ToField
+  *             that describes the mapping between field name and field number.
+  *             The format of this map is defined by Types.Field_Mapping.
+  * @see Types.NumericField
+  * @see Types.Field_Mapping
+  * @see ToField
+  */
 EXPORT FromField(dIn,lOut,dOut,dMap=''):=MACRO
   LOADXML('<xml/>');
   // If a mapping table was specified, we need to join it to the input data

--- a/Interfaces/IClassify.ecl
+++ b/Interfaces/IClassify.ecl
@@ -2,6 +2,11 @@ IMPORT $.^ AS ML_Core;
 IMPORT $.^.Types AS Types;
 
 /**
+  * ***DEPRECATED***
+  * Interface Definition for Classification Modules (version 1)
+  * This interface is being deprecated and should not be used for
+  * new bundles or bundles undergoing substantial revision.
+  * Please use IClassify2 going forward.
  * Interface definition for Classification.  Actual implementation
  * modules will probably take parameters.
  */

--- a/Interfaces/IClassify2.ecl
+++ b/Interfaces/IClassify2.ecl
@@ -1,0 +1,145 @@
+IMPORT $.^ AS ML_Core;
+IMPORT ML_Core.Types AS Types;
+
+Layout_Model2 := Types.Layout_Model2;
+Classify_Result := Types.Classify_Result;
+NumericField := Types.NumericField;
+DiscreteField := Types.DiscreteField;
+Confusion_Detail := Types.Confusion_Detail;
+Classification_Accuracy := Types.Classification_Accuracy;
+Class_Accuracy := Types.Class_Accuracy;
+
+/**
+  * Interface definition for Classification (Version 2).
+  * Classification learns a function that maps a set of input data
+  * to one or more output class-label (i.e. Discrete) variables.
+  * The resulting learned function is known as the model.
+  * That model can then be used repetitively to predict the class(es)
+  * for each sample when presented with new input data.
+  * Actual implementation modules will probably take configuration
+  * parameters to control the classification process.
+  * The Classification modules also expose attributes for assessing
+  * the effectiveness of the classification.
+  */
+EXPORT IClassify2 := MODULE, VIRTUAL
+  /**
+   * Calculate the model to fit the independent data to the observed
+   * classes (i.e. dependent data).
+   * @param indepenedents The observed independent (explanatory) values
+   * @param dependents The observed dependent(class label) values
+   * @return The encoded model
+   * @see Types.Layout_Model2
+   * @see Types.NumericField
+   * @see Types.DiscreteField
+   */
+  EXPORT DATASET(Layout_Model2) GetModel(DATASET(NumericField) independents,
+                                         DATASET(DiscreteField) dependents);
+  /**
+   * Classify the observations using a model.
+   * @param model The model, which must be produced by a corresponding
+   * getModel function.
+   * @param observations New observations (independent data) to be classified.
+   * @return Predicted class values.
+   * 
+   */
+  EXPORT DATASET(DiscreteField) Classify(DATASET(Layout_Model2) model,
+                                         DATASET(NumericField) observations);
+  /**
+    * Return accuracy metrics for the given set of test data
+    * This is equivalent to calling Predict followed by
+    * Analysis.Classification.Accuracy(...).
+    *
+    * Provides accuracy statistics as follows:
+    * - errCount -- The number of misclassified samples
+    * - errPct -- The percentage of samples that were misclasified (0.0 - 1.0)
+    * - RawAccuracy -- The percentage of samples properly classified (0.0 - 1.0)
+    * - PoD -- Power of Discrimination.  Indicates how this classification performed
+    *           relative to a random guess of class.  Zero or negative indicates that
+    *           the classification was no better than a random guess.  1.0 indicates a
+    *           perfect classification.  For example if there are two equiprobable classes,
+    *           then a random guess would be right about 50% of the time.  If this
+    *           classification had a Raw Accuracy of 75%, then its PoD would be .5
+    *           (half way between a random guess and perfection).
+    * - PoDE -- Power of Discrimination Extended.  Indicates how this classification
+    *           performed relative to guessing the most frequent class (i.e. the trivial
+    *           solution).  Zero or negative indicates that this classification is no
+    *           better than the trivial solution.  1.0 indicates perfect classification.
+    *           For example, if 95% of the samples were of class 1, then the trivial
+    *           solution would be right 95% of the time.  If this classification had a
+    *           raw accuracy of 97.5%, its PoDE would be .5 (i.e. half way between
+    *           trivial solution and perfection).
+    * Normally, this should be called using data samples that were not included in the
+    * training set.  In that case, these statistics are considered Out-of-Sample error
+    * statistics.  If it is called with the X and Y from the training set, it provides
+    * In-Sample error stats, which should never be used to rate the classification model.
+    *
+    *
+    * @param model The encoded model as returned from GetModel.
+    * @param actuals The actual class values associated with the observations.
+    * @param observations The independent (explanatory) values on which to base the test
+    * @return Classification accuracy metrics.
+    * @see Types.Classification_Accuracy.
+    *
+    */
+  EXPORT DATASET(Classification_Accuracy) Accuracy(DATASET(Layout_Model2) model,
+                                                   DATASET(DiscreteField) actuals, DATASET(NumericField) observations
+                                                   ) := FUNCTION
+    predicted := Classify(model, observations);
+    RETURN ML_Core.Analysis.Classification.Accuracy(predicted, actuals);
+  END;
+  /**
+    * Return class-level accuracy by class metrics for the given 
+    * set of test data.
+    * This is equivalent to calling Predict followed by
+    * Analysis.Classification.AccuracyByClass(...).
+    *
+    * @param model The encoded model as returned from GetModel.
+    * @param actuals The actual class values associated with the observations.
+    * @param observations The independent (explanatory) values on which to base the test
+    * @return Classification accuracy-by-class metrics for each class.
+    * @see Types.Class_Accuracy.
+    *
+    */
+  EXPORT DATASET(Class_Accuracy) AccuracyByClass(DATASET(Layout_Model2) model,
+                                                   DATASET(DiscreteField) actuals,
+                                                   DATASET(NumericField) observations
+                                                   ) := FUNCTION
+    predicted := Classify(model, observations);
+    RETURN ML_Core.Analysis.Classification.AccuracyByClass(predicted, actuals);
+  END;
+  /**
+    * Return the confusion matrix for a set of test data.
+    * This is equivalent to calling Predict follwed by
+    * Analysis.Classification.ConfusionMatrix(...).
+    * The confusion matrix indicates the number of datapoints that were classified correctly or incorrectly
+    * for each class label.
+    * The matrix is provided as a matrix of size numClasses x numClasses as with fields asfollows:
+    * - 'wi' -- The work item id
+    * - 'pred' -- the predicted class label (from Classify)
+    * - 'actual' -- the actual (target) class label
+    * - 'samples' -- the count of samples that were predicted as 'pred', but should have been 'actual'
+    * - 'totSamples' -- the total number of samples that were predicted as 'pred'
+    * - 'pctSamples' -- the percentage of all samples that were predicted as 'pred', that should
+    *                have been 'actual' (i.e. samples / totSamples)
+    *
+    * This is a useful tool for understanding how the algorithm achieved the overall accuracy.  For example:
+    * were the common classes mostly correct, while less common classes often misclassified?  Which
+    * classes were most often confused?
+    *
+    * This should be called with test data that is independent of the training data in order to understand
+    * the out-of-sample (i.e. generalization) performance.
+    *
+    * @param model The encoded model as returned from GetModel.
+    * @param actuals The actual class values.
+    * @param observations The independent (explanatory) values.
+    * @return The confusion matrix showing correct and incorrect
+    *         results.
+    * @see Types.Confusion_Detail.
+    */
+  EXPORT DATASET(Confusion_Detail) ConfusionMatrix(DATASET(Layout_Model2) model,
+                                                   DATASET(DiscreteField) actuals, DATASET(NumericField) observations
+                                                   ) := FUNCTION 
+    predicted := Classify(model, observations);
+    RETURN ML_Core.Analysis.Classification.ConfusionMatrix(predicted, actuals);
+  END;
+END;

--- a/Interfaces/IRegression.ecl
+++ b/Interfaces/IRegression.ecl
@@ -16,7 +16,11 @@ null_model := DATASET([], Layout_Model);
 empty_data := DATASET([], NumericField);
 
 /**
-  * Interface Definition for Regression Modules
+  * ***DEPRECATED***
+  * Interface Definition for Regression Modules (version 1)
+  * This interface is being deprecated and should not be used for
+  * new bundles or bundles undergoing substantial revision.
+  * Please use IRegression2 going forward.
   *
   * Regression learns a function that maps a set of input data
   * to one or more output variables.  The resulting learned function is

--- a/Interfaces/IRegression2.ecl
+++ b/Interfaces/IRegression2.ecl
@@ -1,0 +1,80 @@
+/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2016 HPCC Systems®.  All rights reserved.
+############################################################################## */
+IMPORT $.^ as ML_Core;
+IMPORT ML_Core.Types;
+
+//IMPORT PBblas.Types AS PBBTypes;
+AnyField     := Types.AnyField;
+NumericField := Types.NumericField;
+Layout_Model2 := Types.Layout_Model2;
+Regression_Accuracy := Types.Regression_Accuracy;
+t_work_item  := Types.t_work_item;
+t_RecordID   := Types.t_RecordID;
+t_FieldNumber := Types.t_FieldNumber;
+t_FieldReal   := Types.t_FieldReal;
+null_model := DATASET([], Layout_Model2);
+empty_data := DATASET([], NumericField);
+
+/**
+  * Interface Definition for Regression Modules (Version 2)
+  *
+  * Regression learns a function that maps a set of input data
+  * to one or more continuous output variables.  The resulting learned function is
+  * known as the model.  That model can then be used repetitively to predict
+  * (i.e. estimate) the output value(s) based on new input data.
+  * Actual implementation modules will probably take configuration
+  * parameters to control the regression process.
+  * The regression modules also expose attributes for assessing the effectiveness
+  * of the regression.
+  *
+  */
+EXPORT IRegression2 := MODULE, VIRTUAL
+  /**
+    * Calculate and return the 'learned' model
+    *
+    * The model may be persisted and later used to make predictions
+    * using 'Predict' below.
+    *
+    * @param independents The independent data in DATASET(NumericField) format.
+    *          Each statistical unit (e.g. record) is identified by
+    *          'id', and each feature is identified by field number (i.e.
+    *          'number').
+    * @param dependents The dependent variable(s) in DATASET(NumericField) format.
+    *          Each statistical unit (e.g. record) is identified by
+    *          'id', and each feature is identified by field number (i.e.
+    *          'number').
+    * @return The encoded model
+    * @see Types.NumericField
+    * @see Types.Layout_Model2
+    */
+  EXPORT DATASET(Layout_Model2) GetModel(DATASET(NumericField) independents,
+                   DATASET(NumericField) dependents);
+  /**
+    * Predict the output variable(s) based on a previously learned model
+    *
+    * @param independents the observations upon which to predict.
+    * @return one entry per observation (i.e. id)
+    *                  in observations.  This represents the predicted values for the dependent
+    *                  variable(s).
+    *
+    */
+  EXPORT DATASET(NumericField) Predict(DATASET(Layout_Model2) model, DATASET(NumericField) observations);
+
+  /**
+    * Assess the accuracy of a set of predictions.
+    *
+    * This is equivalent to calling predict and then Analysis.Regression.Accuracy.
+    *
+    * @param model The model as returned from GetModel
+    * @param actuals The actual values of the dependent variable to compare with the predictions.
+    * @param observations The independent data upon which the accuracy assessment is to be based.
+    * @return Accuracy statistics (see Types.Regression_Accuracy for details)
+    *
+    */
+  EXPORT DATASET(Regression_Accuracy) Accuracy(DATASET(Layout_Model2) model, DATASET(NumericField) actuals,
+          DATASET(NumericField) observations) := FUNCTION
+    predicted := Predict(model, observations);
+    RETURN ML_Core.Analysis.Regression.Accuracy(predicted, actuals);
+  END;
+END;

--- a/ModelOps2.ecl
+++ b/ModelOps2.ecl
@@ -1,0 +1,254 @@
+/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2017 HPCC Systems®.  All rights reserved.
+############################################################################## */
+IMPORT $ AS ML_Core;
+IMPORT ML_Core.Types;
+
+NumericField := Types.NumericField;
+Layout_Model2 := Types.Layout_Model2;
+t_indexes := Types.t_indexes;
+t_Work_Item := Types.t_Work_Item;
+t_FieldReal := Types.t_FieldReal;
+
+/**
+  * This module provides a set of operations to provide manipulation of machine
+  * learning models (version 2) in the Types.Layout_Model2 format.  The theory-
+  * of-operation for use of this type of model is described below:
+  *
+  * Layout_Model2 defines a flexible structure that allows storage of model information for
+  * any Machine Learning algorithm.
+  *
+  * The model is based on a "Naming Tree" paradigm.
+  *
+  * The naming tree is a data structure that allows a hierarchical name (e.g.
+  * object-id) to be attached to each data-cell.  Examples of naming-trees are
+  * OID trees such as those used in various network identifiers such as MIBs
+  *
+  * This structure is used within ML to store model information.  It is a
+  * useful format for several reasons:
+  * - It has the flexibility to store complex sets of data in a generic way
+  * - It easily stores scalar as well as matrix oriented data
+  * - It allows a model to contain data elements within scopes that are
+  *   defined at different level.  For example, part of the model may be defined
+  *   globally, another may be common for a bundle, while another section is
+  *   specific to a given module.
+  * - It readily allows composite models to be created by encapsulating
+  *   entire complex models (or sets of models) within branches of another model.
+  *   The individual models can then be extracted from the composite model, and
+  *   passed to the modules that created them.
+  *
+  * Theory of Operation
+  * 
+  * The naming tree (NT) is conceptually simple.  Each cell is identified by a
+  * hierarchical numbering scheme of arbitrary depth.  Take, for example, the following
+  * NT:
+  * 1
+  *   1.1
+  *     1.1.1
+  *     1.1.2
+  *   1.2
+  *     1.2.1
+  *     1.2.2
+  * 2
+  * This tree defines the following leaf (scalar) elements: 1.1.1, 1.1.2, 1.2.1, 1.2.2, 2.
+  * Note that the deepest node on any branch is considered a leaf, and branches can be of
+  * variable depth.  Note also that there is no explicit creation of branch nodes.  The 
+  * branches are implicitly defined by the ids of the leafs.
+  * In this example, node 1.1 can be thought as representing an array, thought it could
+  * also be thought of as a structure of two distinct scalars, depending on whether the user
+  * expects a variable length list under 1.1 (i.e. 1.1.1 - 1.1.N) or a fixed set of cells.
+  * Likewise node 1 can be thought of as a matrix (1.r.c, where r is the row index and c
+  * is the column index), in cases where r and c are of variable size.
+  * 
+  * This naming tree also supports the myriad interface, allowing multiple independent
+  * work-items to be represented, each of which may duplicate the same structure.
+  * 
+  * The id is represented by an ECL SET of Unsigned identifiers (e.g. [1,2,1] represents the OID 1.2.1).
+  *
+  * Each cell is defined by three fields: wi (work-item-id), value (the cell contents) and
+  * indexes (the id).
+  * A naming tree can be constructed as an inline dataset.  For example, the following
+  * creates the tree in the example above:  DATASET([{1, 3.2, [1,1,1]},
+  *                                                  {1, .0297, [1,1,2]},
+  *                                                  {1, 2.0, [1,2,1]},
+  *                                                  {1, 1550, [1,2,2]},
+  *                                                  {1, 8.1, [2]}], Layout_Model2);
+  * There are attributes in this module to assist with manipulation of naming trees:
+  * - Creating a NT from a NumericField matrix
+  * - Extracting a NumericField matrix from an NT branch
+  * - Inserting an NT onto a branch of another NT
+  * - Extracting an NT from a branch of an NT
+  *
+  * @see Types.Layout_Model2
+  */
+EXPORT ModelOps2 := MODULE
+  SHARED empty_array := DATASET([], Layout_Model2);
+  /**
+    * Extract an inner sub-tree from an existing model
+    * Work-item = 0 (default) will extract all work-items
+    * This is the opposite of Insert.
+    *
+    * For example If I have a tree:
+    * 1
+    * 2
+    * 3
+    *   3.1
+    *   3.2
+    * and I extract from index 3, it will return the Naming Tree:
+    * 1
+    * 2
+    * containing the two sub-cells of the original index 3
+    *
+    * @param nt The model from which to extract the sub-tree
+    * @param fromIndx The index from which to extract the subtree
+    * @param fromWi The work-item to extract or 0 to extract the same
+    *               sub-tree from all work-items
+    * @return A model containing all of the sub-cells below fromIndx
+    *         with the indexes adjusted to the top of the tree.
+    *
+    */
+  EXPORT DATASET(Layout_Model2) Extract(DATASET(Layout_Model2) mod,
+                                       t_indexes fromIndx, t_work_item fromWi=0) := FUNCTION
+    Layout_Model2 extract_indexes(Layout_Model2 a, UNSIGNED prefixSize) := TRANSFORM
+      outIndex := a.indexes[prefixSize+1.. ];
+      SELF.indexes := outIndex;
+      SELF         := a;
+    END;
+    prefixSize := COUNT(fromIndx);
+    filter := mod.indexes[..prefixSize] = fromIndx AND (fromWi = 0 OR mod.wi = fromWi);
+    outMod    := PROJECT(mod(filter), extract_indexes(LEFT, prefixSize));
+    return outMod;
+  END;
+  /**
+    * Extend the indices of a model to fit within a deeper model
+    *
+    * For example, a cell with index [1,2] could be moved to index [1,2,3,1,2]
+    * by using atIndex := [1,2,3].
+    *
+    * @param mod The model whose indexes are to be extended
+    * @param atIndex The prefix indexes to be prepended to the indexes of each cell
+    *                in mod
+    * @return A model with extended indexes
+    *
+    */
+  EXPORT DATASET(Layout_Model2) ExtendIndices(DATASET(Layout_Model2) mod, t_indexes atIndex) := FUNCTION
+    Layout_Model2 extend_indexes(Layout_Model2 t) := TRANSFORM
+      indxs := atIndex + t.indexes;
+      SELF.indexes := indxs;
+      SELF         := t;
+    END;
+    outMod := PROJECT(mod, extend_indexes(LEFT));
+    return outMod;
+  END;
+  /**
+    * Insert an model into a sub-tree of an existing model
+    *
+    * Extends the indexes of the provided model to fit onto a branch
+    * of another model, and concatenates the two models. This is the opposite of
+    * extract.
+    * For example: If I have a model:
+    * 1
+    * 2
+    * and a second model:
+    * 1
+    * 2
+    * 3
+    * That I would like to insert into the first tree at index 3, I would
+    * end up with the tree:
+    * 1
+    * 2
+    * 3
+    *  3.1
+    *  3.2
+    *  3.3
+    * Example code: mod3 := Insert(mod1, mod2, [3]);
+    *
+    * @param mod1 The first (base) model
+    * @param mod2 The sub-model that is to be inserted into mod1
+    * @param atIndx The index prefix (in mod1) that will contain the cells from mod2
+    * @return a new model containing the cells from both models
+    *
+    */
+  EXPORT DATASET(Layout_Model2) Insert(DATASET(Layout_Model2) mod1, DATASET(Layout_Model2) mod2, t_indexes atIndx) := FUNCTION
+    mod2a := ExtendIndices(mod2, atIndx);
+    RETURN mod1 + mod2a;
+  END;
+  /**
+    * Convert a two-level model or model sub-tree into a NumericField dataset
+    *
+    * The last two indexes of the model subtree are used as the indexes for the NumericField
+    * matrix.  The second to last index corresponds to the NF's id field and the
+    * last index corresponds to the NF's number field.
+    *
+    * @param mod The model from which to extract the NumericField matrix
+    * @param fromIndex The index from which to extract the matrix. Example: [3,1,5].
+    *                  The default is from the top of the tree i.e. [].
+    * @return NumericField matrix in DATASET(NumericField) format.
+    *
+    */
+  EXPORT DATASET(NumericField) ToNumericField(DATASET(Layout_Model2) mod, t_indexes fromIndx = []) := FUNCTION
+    NumericField mod_to_nf(Layout_Model2 t) := TRANSFORM
+      prefixSize := COUNT(fromIndx);
+      suffix := t.indexes[prefixSize+1.. ];
+      SELF.id := suffix[1];
+      SELF.number := suffix[2];
+      SELF := t;
+    END;
+    prefixSize := COUNT(fromIndx);
+    filter := mod.indexes[..prefixSize] = fromIndx;
+    outCells := ASSERT(mod(filter), COUNT(indexes) = prefixSize + 2, 'ModelOps2.ToNumericField: Extracted indexes must be exactly 2 dimensional.  Found '
+                                       + (COUNT(indexes) - prefixSize), FAIL);
+    outMod := PROJECT(outCells, mod_to_nf(LEFT));
+    return outMod;
+  END;
+  /**
+    * Convert a NumericField dataset to a 2 level model (or model subtree)
+    *
+    * A two level model is created and appended to atIndex.
+    * The first new index will contain the value of the NumericField's
+    * id field, and the second will contain the value of the NumericField's
+    * number field.
+    * Example: If I have a NumericField with id=1 and number=3, and I use
+    * atIndex = [3,1,5], it will create a Naming Tree cell with indexes:
+    * [3,1,5,1,3].
+    * 
+    * @param nf A NumericField dataset to be converted
+    * @param atIndex The index at which to place the new subtree e.g., [3,1,5]
+    * @return DATASET(ntNumeric) Naming Tree.
+    *
+    */
+  EXPORT DATASET(Layout_Model2) FromNumericField(DATASET(NumericField) nf, t_indexes atIndex=[]) := FUNCTION
+    Layout_Model2 nf_to_mod(NumericField n) := TRANSFORM
+      indexes := atIndex + [n.id, n.number];
+      SELF.indexes := indexes;
+      SELF         := n;
+    END;
+    outMod := PROJECT(nf, nf_to_mod(LEFT));
+    RETURN outMod;
+  END;
+  /**
+    * Get a single record (cell) from a model by index
+    *
+    * @param mod The model (DATASET(layout_model2)) from which to extract the cell
+    * @param indxs The id of the cell to extract (e.g. [3,1,5])
+    * @param wi_num The work-item number to extract the cell from, default = 1.
+    * @return The model cell (Layout_Model2) or an empty cell (wi=0) if not found.
+    *
+    */
+  EXPORT Layout_Model2 GetItem(DATASET(Layout_Model2) mod, t_indexes indxs, wi_num=1) := FUNCTION
+    RETURN mod(indexes=indxs AND wi=wi_num)[1];
+  END;
+  /**
+    * Add a single record (cell) to an model at a given set of coordinates
+    *
+    * @param nt The Naming Tree to which to add a cell
+    * @param wi The work-item associated with the cell
+    * @param indexes The indices for the cell
+    * @param value The value of the cell
+    * @return Model with the added cell
+    *
+    */
+  EXPORT DATASET(Layout_Model2) SetItem(DATASET(Layout_Model2) mod, t_work_item wi, t_indexes indexes, t_fieldReal value) := FUNCTION
+    RETURN mod + DATASET([{wi, value, indexes}], Layout_Model2);
+  END;
+END;

--- a/Tests/Validate_Betas.ecl
+++ b/Tests/Validate_Betas.ecl
@@ -1,7 +1,7 @@
 // Compare Beta against the scipy implementation of Beta for validation
 //We only expose the Beta at this point, but test is intended to be
 //expanded to add the incomplete (lower) Beta.
-IMPORT ML_Core;
+IMPORT $.^ AS ML_Core;
 IMPORT ML_Core.Math;
 IMPORT Python;
 REAL8 scipy_beta(REAL8 x, REAL8 y) := EMBED(Python)

--- a/Tests/test_Analysis.ecl
+++ b/Tests/test_Analysis.ecl
@@ -1,0 +1,86 @@
+/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.  All rights reserved.
+############################################################################## */
+IMPORT $.^ AS ML_Core;
+
+IMPORT ML_Core.Analysis;
+IMPORT ML_Core.Types;
+
+DiscreteField := Types.DiscreteField;
+NumericField := Types.NumericField;
+
+num_samples := 100;
+num_classes := 5; // Number of class labels -- should be a factor of num_samples
+num_variables := 2; // Number of classification variables (i.e. for multi-variate) --
+                   // should be a factor of num_samples
+num_wis := 3;  // Number of work-items -- should be a factor of num_samples
+
+DiscreteField make_discrete(UNSIGNED c) := TRANSFORM
+  SELF.wi := (c-1) DIV (num_samples * num_variables) + 1;
+  SELF.number := (c-1) % num_variables + 1;
+  SELF.id := c;
+  SELF.value := ((c-1) DIV num_variables) % num_classes + 1;
+END;
+
+// Generate "actual" data for classification
+class_actual := DATASET(num_samples * num_wis * num_variables, make_discrete(COUNTER));
+
+OUTPUT(class_actual, ALL, NAMED('class_actual'));
+
+class_pred := PROJECT(class_actual, TRANSFORM(DiscreteField,
+                      SELF.value := IF((COUNTER-1) DIV num_variables % 4 = 0,
+                                      IF(LEFT.value = num_classes, 1, LEFT.value + 1),
+                                      LEFT.value); // Modify every fourth value by incrementing
+                                                   // circularly.
+                      SELF := LEFT));
+OUTPUT(class_pred, ALL, NAMED('class_pred'));
+// Distribute actual and pred by wi, number, and id
+class_actualD := DISTRIBUTE(class_actual, HASH32(wi, number, id));
+class_predD := DISTRIBUTE(class_pred, HASH32(wi, number, id));
+
+class_stats := Analysis.Classification.ClassStats(class_actualD);
+
+OUTPUT(class_stats, ALL, NAMED('class_stats'));
+
+class_accuracy := Analysis.Classification.Accuracy(class_predD, class_actualD);
+
+OUTPUT(class_accuracy, ALL, NAMED('class_accuracy'));
+
+accuracy_by_class := Analysis.Classification.AccuracyByClass(class_predD, class_actualD);
+
+OUTPUT(accuracy_by_class, ALL, NAMED('accuracy_by_class'));
+
+confusion_matrix := Analysis.Classification.ConfusionMatrix(class_predD, class_actualD);
+
+OUTPUT(confusion_matrix, ALL, NAMED('confusion_matrix'));
+
+// Now test Regression Analysis
+maxU4 := POWER(2, 32) - 1;
+NumericField make_numeric(UNSIGNED c) := TRANSFORM
+  SELF.wi := (c-1) DIV (num_samples * num_variables) + 1;
+  SELF.number := (c-1) % num_variables + 1;
+  SELF.id := c;
+  SELF.value := RANDOM() / maxU4 - .5;
+END;
+
+noiseLevel := .5;
+noise := RANDOM() / maxU4 * noiseLevel - (noiseLevel/2);
+
+// Generate "actual" data for classification
+regr_actual := DATASET(num_samples * num_wis * num_variables, make_numeric(COUNTER));
+
+OUTPUT(regr_actual, ALL, NAMED('regr_actual'));
+
+regr_pred := PROJECT(regr_actual, TRANSFORM(NumericField,
+//                      SELF.value := IF((LEFT.id-1)%2 = 0, LEFT.value + noiseLevel,
+//                                                          LEFT.value - noiseLevel),
+                      SELF.value := LEFT.value + noise,
+                      SELF := LEFT));
+OUTPUT(regr_pred, ALL, NAMED('regr_pred'));
+// Distribute actual and pred by wi, number, and id
+regr_actualD := DISTRIBUTE(regr_actual, HASH32(wi, number, id));
+regr_predD := DISTRIBUTE(regr_pred, HASH32(wi, number, id));
+
+regr_accuracy := Analysis.Regression.Accuracy(regr_predD, regr_actualD);
+
+OUTPUT(regr_accuracy, NAMED('regr_accuracy'));

--- a/Tests/test_Crossval.ecl
+++ b/Tests/test_Crossval.ecl
@@ -1,0 +1,114 @@
+/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.  All rights reserved.
+############################################################################## */
+// This test exercises the CrossValidation module.
+// Note that in order for this test to work, the LearningTrees module
+// must be installed because we need some bundle to test against.
+// This file may show up with an error if LearningTrees is not installed,
+// but that does not affect the rest of the bundle.
+IMPORT $.^ AS ML_Core;
+
+/**
+  * Use the Cover Type database of Rocky Mountain Forest plots.
+  * Perform a Random Forest classification to determine the primary Cover Type
+  * (i.e. tree species) for each plot of land.
+  * Do not be confused by the fact that we are using Random Forests to predict
+  * tree species in an actual forest :)
+  * @see test/datasets/CovTypeDS.ecl
+  */
+IMPORT LearningTrees AS LT;
+IMPORT LT.LT_Types;
+IMPORT LT.test.datasets.CovTypeDS;
+IMPORT ML_Core.Types;
+
+numTrees := 20;
+maxDepth := 255;
+numFeatures := 0; // Zero is automatic choice
+balanceClasses := FALSE;
+nonSequentialIds := TRUE; // True to renumber ids, numbers and work-items to test
+                            // support for non-sequentiality
+numWIs := 2;     // The number of independent work-items to create
+maxRecs := 5000; // Filter on the number of records to use.  Max is 5000.
+numFolds := 10;
+t_Discrete := Types.t_Discrete;
+t_FieldReal := Types.t_FieldReal;
+DiscreteField := Types.DiscreteField;
+NumericField := Types.NumericField;
+trainDat := CovTypeDS.trainRecs;
+testDat := CovTypeDS.testRecs;
+ctRec := CovTypeDS.covTypeRec;
+nominalFields := CovTypeDS.nominalCols;
+numCols := CovTypeDS.numCols;
+
+
+ML_Core.ToField(trainDat, trainNF);
+ML_Core.ToField(testDat, testNF);
+
+// First test Classification Cross-Validation
+
+X0 := PROJECT(trainNF(number != 52 AND id <= maxRecs), TRANSFORM(NumericField,
+        SELF.number := IF(nonSequentialIds, 5*LEFT.number, LEFT.number),
+        SELF.id := IF(nonSequentialIds, 5*LEFT.id, LEFT.id),
+        SELF := LEFT));
+Y0 := PROJECT(trainNF(number = 52 AND id <= maxRecs), TRANSFORM(DiscreteField,
+        SELF.number := 1,
+        SELF.id := IF(nonSequentialIds, 5*LEFT.id, LEFT.id),
+        SELF := LEFT));
+// Generate multiple work items
+X := NORMALIZE(X0, numWIs, TRANSFORM(RECORDOF(LEFT),
+          SELF.wi := IF(nonSequentialIds, 5*COUNTER, COUNTER),
+          SELF := LEFT));
+Y := NORMALIZE(Y0, numWIs, TRANSFORM(RECORDOF(LEFT),
+          SELF.wi := IF(nonSequentialIds, 5*COUNTER, COUNTER),
+          SELF := LEFT));
+
+myLearner := LT.ClassificationForest(numTrees, numFeatures, maxDepth); 
+
+rslt := ML_Core.CrossValidation.NFoldCV(myLearner, X, Y, numFolds);
+
+modC := rslt.Model;
+modStats := myLearner.GetModelStats(modC);
+
+OUTPUT(modStats, NAMED('ModelStatistics'));
+OUTPUT(rslt.ClassStats, NAMED('ClassStats'));
+OUTPUT(rslt.Accuracy, NAMED('Accuracy'));
+OUTPUT(rslt.AccuracyByClass, NAMED('AccuracyByClass'));
+OUTPUT(rslt.ConfusionMatrix, NAMED('ConfusionMatrix'));
+
+// Now test Regression
+
+XR0 := PROJECT(trainNF(number != 1), TRANSFORM(NumericField,
+        SELF.number := IF(nonSequentialIds, (5*LEFT.number -1), LEFT.number -1),
+        SELF.id := IF(nonSequentialIds, 5*LEFT.id, LEFT.id),
+        SELF := LEFT));
+YR0 := PROJECT(trainNF(number = 1), TRANSFORM(NumericField,
+        SELF.number := 1,
+        SELF.id := IF(nonSequentialIds, 5*LEFT.id, LEFT.id),
+        SELF := LEFT));
+// Generate multiple work items
+XR := NORMALIZE(XR0, numWIs, TRANSFORM(RECORDOF(LEFT),
+          SELF.wi := IF(nonSequentialIds, 5*COUNTER, COUNTER),
+          SELF := LEFT));
+YR := NORMALIZE(YR0, numWIs, TRANSFORM(RECORDOF(LEFT),
+          SELF.wi := IF(nonSequentialIds, 5*COUNTER, COUNTER),
+          SELF := LEFT));
+
+IMPORT Python;
+SET OF UNSIGNED incrementSet(SET OF UNSIGNED s, INTEGER increment) := EMBED(Python)
+  outSet = []
+  for i in range(len(s)):
+    outSet.append(s[i] + increment)
+  return outSet
+ENDEMBED;
+// Fixup IDs of nominal fields to match
+nomFields := incrementSet(nominalFields, -1);
+
+myLearnerR := LT.RegressionForest(numTrees, numFeatures, maxDepth);
+
+rsltR := ML_Core.CrossValidation.NFoldCV(myLearnerR, XR, YR, numFolds);
+modR := rsltR.Model;
+
+modStatsR := myLearnerR.GetModelStats(modR);
+
+OUTPUT(modStatsR, NAMED('RegressionModelStatistics'));
+OUTPUT(rsltR.Accuracy, NAMED('RegressionAccuracy'));

--- a/Tests/test_ModelOps2.ecl
+++ b/Tests/test_ModelOps2.ecl
@@ -1,0 +1,42 @@
+/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.  All rights reserved.
+############################################################################## */
+/**
+  * This module provides tests for the ModelOps2 module
+  */
+IMPORT $.^ as ML_Core;
+IMPORT ML_Core.Types;
+IMPORT ML_Core.ModelOps2;
+Layout_Model2 := Types.Layout_Model2;
+
+mod := DATASET([
+                  {1, 1.1, [1, 5, 1, 1]},
+                  {1, 1.2, [1, 5, 1, 2]},
+                  {1, 1.3, [1, 5, 1, 3]},
+                  {1, 2.1, [1, 5, 2, 1]},
+                  {1, 2.2, [1, 5, 2, 2]},
+                  {1, 2.3, [1, 5, 2, 3]},
+                  {1, .16, [1, 6, 1, 1]},
+                  {1, .25, [2, 5, 1, 1]}
+                  ], Layout_Model2);
+rslt1 := ModelOps2.ToNumericField(mod, [1,5]);
+
+rslt2 := ModelOps2.FromNumericField(rslt1, [5,10]);
+
+rslt3_1 := ModelOps2.GetItem(rslt2, [5, 10, 2, 3]);
+rslt3_2 := ModelOps2.GetItem(rslt2, [5, 10, 2, 3], 2);  // Shouldn't find it -- no wi = 2
+
+rslt4 := ModelOps2.SetItem(rslt2, 1, [5, 10, 2, 4], 2.4);
+
+rslt5 := ModelOps2.Extract(rslt4, [5, 10, 2]);
+
+rslt6 := ModelOps2.Insert(mod, rslt5, [1, 6, 1, 1]);
+
+OUTPUT(mod, NAMED('Model'));
+OUTPUT(rslt1, NAMED('ToNF'));
+OUTPUT(rslt2, NAMED('FromNF'));
+OUTPUT(rslt3_1, NAMED('GetItem'));
+OUTPUT(rslt3_2, NAMED('GetItemNotFound'));
+OUTPUT(rslt4, NAMED('SetItem'));
+OUTPUT(rslt5, NAMED('Extract'));
+OUTPUT(rslt6, NAMED('Insert'));

--- a/ToField.ecl
+++ b/ToField.ecl
@@ -1,43 +1,48 @@
-//IMPORT $.Types AS Types;
-//---------------------------------------------------------------------------
-// Macro takes a matrix dataset, with each row contianing an ID and one or
-// more axis fields containing numeric values, and expands it into the
-// NumericField format used by ML.
-//
-//   dIn       : The name of the input dataset
-//   dOut      : The name of the resulting dataset
-//   idfield   : [OPTIONAL] The name of the field that contains the UID for
-//               each row.  If omitted, it is assumed to be the first field.
-//   wifield   : [OPTIOPNAL] The name of the field that contains the
-//               work item value.  A constant is used if the field name
-//               is not supplied.
-//   wivalue   : [OPTIONAL} The constant value to use for work item.
-//               The value 1 is used if not supplied.
-//   datafields: [OPTIONAL] A STRING contianing a comma-delimited list of the
-//               fields to be treated as axes.  If omitted, all numeric
-//               fields that are not the UID will be treated as axes.
-//               NOTE: idfield defaults to the first field in the table, so
-//               if that field is specified as an axis field, then the user
-//               should be sure to specify a value in the idfield param.
-//
-//  Along with creating the NumericField table, this macro produces two
-//  simple functions to assist the user in mapping the field names to their
-//  corresponding numbers.  These are "STRING dOut_ToName(UNSIGNED)" and
-//  "UNSIGNED dOut_ToNumber(STRING)", where the "dOut" portion of the function
-//  name is the name passed into that parameter of the macro.
-//
-//  The macro also produces a mapping table named "dOut_Map", again where
-//  "dOut" refers to the parameter, that contains a table of the field
-//  mappings
-//
-//  Examples:
-//    ML.ToField(dOrig,dMatrix);
-//    ML.ToField(dOrig,dMatrix,myid,'field5,field7,field10');
-//    dMatrix_ToName(2);  // returns 'field7'
-//    dMatrix_ToNumber('field10'); // returns 3
-//    dMatrix_Map; // returns the mapping table of field name to number
-//---------------------------------------------------------------------------
-EXPORT ToField(dIn,dOut,idfield='', wifield='', wivalue='',datafields=''):=MACRO
+/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.  All rights reserved.
+############################################################################## */
+/** 
+  * ToField Macro takes a matrix dataset, with each row containing an ID and one or
+  * more axis fields containing numeric values, and expands it into the
+  * NumericField format used by ML.
+  *
+  * @param dIn The name of the input dataset
+  * @param dOut The name of the resulting dataset
+  * @param idfield [OPTIONAL] The name of the field that contains the UID for
+  *                each row.  If omitted, it is assumed to be the first field.
+  * @param wifield [OPTIONAL] The name of the field that contains the
+  *                work item value.  A constant is used if the field name
+  *                is not supplied (as provided by wivalue below)
+  * @param wivalue [OPTIONAL} The constant value to use for work item.
+  *                The value 1 is used if not supplied.
+  * @param datafields [OPTIONAL] A STRING containing a comma-delimited list of the
+  *                   fields to be treated as axes.  If omitted, all numeric
+  *                   fields that are not the idfield or wifield will be treated as axes.
+  *                   NOTE: idfield defaults to the first field in the table, so
+  *                   if that field is specified as an axis field, then the user
+  *                   should be sure to specify a value in the idfield param.
+  * @return Nothing.  The MACRO creates new attributes in-line as described below.
+  *
+  * Along with creating the NumericField table, this macro produces two
+  * simple functions to assist the user in mapping the field names to their
+  * corresponding numbers.  These are "STRING dOut_ToName(UNSIGNED)" and
+  * "UNSIGNED dOut_ToNumber(STRING)", where the "dOut" portion of the function
+  * name is the name passed into that parameter of the macro.
+  *
+  * The macro also produces a mapping table named "dOut_Map", again where
+  * "dOut" refers to the parameter, that contains a table of the field
+  * mappings.  See Types.Field_Mapping for the layout of this mapping dataset.
+  *
+  * Examples:
+  *   ML.ToField(dOrig,dMatrix);
+  *   ML.ToField(dOrig,dMatrix,myid,'field5,field7,field10');
+  *   dMatrix_ToName(2);    // returns 'field7'
+  *   dMatrix_ToNumber('field10'); // returns 3
+  *   dMatrix_Map;  // returns the mapping table of field name to number see 
+  *                 // Types.Field_Mapping
+  *
+  */
+EXPORT ToField(dIn, dOut, idfield='', wifield='', wivalue='', datafields=''):=MACRO
   IMPORT ML_Core;
   LOADXML('<xml/>');
   // Variable to contain the name if the field that maps to "wi", or the value


### PR DESCRIPTION
Note: Also incorporates ML-389 and ML-384
Add IRegression2 interface
Mark IRegression interface as deprecated
Add Layout_Model2 to Types
Add ModelOps2 file for operations on Layout_Model2
Also satisfies ML-389 Common Capabilities:
- Add Analysis module providing common accuracy stats for classification and regression
- Add test for Analysis module
- Add Cross Validation module
- Add test for Cross Validation module
Also satisfies ML-384 Improve documentation for FromField and ToField macros
- Improve documentation for ToField and FromField macros
Improve documentation of Types definitions
Update bundle version to 3.2.0